### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Participantletter/Form/Event/Config.php
+++ b/CRM/Participantletter/Form/Event/Config.php
@@ -70,8 +70,8 @@ class CRM_Participantletter_Form_Event_Config extends CRM_Event_Form_ManageEvent
     $eventSettings = CRM_Participantletter_Settings::getEventSettings($this->getEntityId());
     $defaults = array(
       'event_id' => $this->getEntityId(),
-      'template_id' => CRM_Utils_Array::value('template_id', $eventSettings),
-      'is_participantletter' => CRM_Utils_Array::value('is_participantletter', $eventSettings),
+      'template_id' => $eventSettings['template_id'] ?? NULL,
+      'is_participantletter' => $eventSettings['is_participantletter'] ?? NULL,
     );
     $this->setDefaults($defaults);
 
@@ -92,8 +92,8 @@ class CRM_Participantletter_Form_Event_Config extends CRM_Event_Form_ManageEvent
 
   public function postProcess() {
     $eventSettings = array(
-      'template_id' => CRM_Utils_Array::value('template_id', $this->_submitValues),
-      'is_participantletter' => CRM_Utils_Array::value('is_participantletter', $this->_submitValues),
+      'template_id' => $this->_submitValues['template_id'] ?? NULL,
+      'is_participantletter' => $this->_submitValues['is_participantletter'] ?? NULL,
     );
     if (CRM_Participantletter_Settings::saveAllEventSettings($this->getEntityId(), $eventSettings)) {
       CRM_Core_Session::setStatus(" ", E::ts('Settings saved.'), "success");

--- a/CRM/Participantletter/Settings.php
+++ b/CRM/Participantletter/Settings.php
@@ -28,7 +28,7 @@ class CRM_Participantletter_Settings {
 
     $createParams = array();
 
-    if ($optionValueId = CRM_Utils_Array::value('id', $result)) {
+    if ($optionValueId = $result['id'] ?? NULL) {
       $createParams['id'] = $optionValueId;
     }
     else {

--- a/participantletter.php
+++ b/participantletter.php
@@ -5,7 +5,7 @@ use CRM_Participantletter_ExtensionUtil as E;
 
 function participantletter_civicrm_tabset($tabsetName, &$tabs, $context) {
   if ($tabsetName == 'civicrm/event/manage') {
-    $eventId = CRM_Utils_Array::value('event_id', $context);
+    $eventId = $context['event_id'] ?? NULL;
     if (!empty($eventId)) {
       $eventSettings = CRM_Participantletter_Settings::getEventSettings($eventId);
       $tabs['participantletter'] = array(
@@ -33,9 +33,9 @@ function participantletter_civicrm_tabset($tabsetName, &$tabs, $context) {
 
   // on manage events listing screen, this section sets particpantletter tab in configuration popup as enabled/disabled.
   if ($tabsetName == 'civicrm/event/manage/rows' && CRM_Utils_Array::value('event_id', $context)) {
-    if ($eventId = CRM_Utils_Array::value('event_id', $context)) {
+    if ($eventId = $context['event_id'] ?? NULL) {
       $eventSettings = CRM_Participantletter_Settings::getEventSettings($eventId);
-      $tabs[$eventId]['is_participantletter'] = CRM_Utils_Array::value('is_participantletter', $eventSettings);
+      $tabs[$eventId]['is_participantletter'] = $eventSettings['is_participantletter'] ?? NULL;
     }
   }
 }
@@ -45,7 +45,7 @@ function participantletter_civicrm_post($op, $objectName, $objectId, &$objectRef
     $eventSettings = CRM_Participantletter_Settings::getEventSettings($objectRef->event_id);
     if (
       CRM_Utils_Array::value('is_participantletter', $eventSettings)
-      && ($template_id = CRM_Utils_Array::value('template_id', $eventSettings))
+      && ($template_id = $eventSettings['template_id'] ?? NULL)
       && CRM_Participantletter_Utils::canSendEmail()
       && !($objectRef->is_test)
     ) {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.