### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Participantletter/Settings.php
+++ b/CRM/Participantletter/Settings.php
@@ -47,7 +47,7 @@ class CRM_Participantletter_Settings {
       civicrm_api3('optionValue', 'create', $createParams);
       return TRUE;
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       return FALSE;
     }
   }

--- a/CRM/Participantletter/Upgrader.php
+++ b/CRM/Participantletter/Upgrader.php
@@ -55,7 +55,7 @@ class CRM_Participantletter_Upgrader extends CRM_Extension_Upgrader_Base {
         'id' => $optionGroupId,
       ));
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
     }
   }
 

--- a/participantletter.php
+++ b/participantletter.php
@@ -57,7 +57,7 @@ function participantletter_civicrm_post($op, $objectName, $objectId, &$objectRef
         civicrm_api3('email', 'send', $params);
         CRM_Core_Error::debug_log_message("Participantletter: Successfully sent email to participant_id: {$objectRef->id}, contact_id: {$objectRef->contact_id}, template_id: {$template_id}");
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         CRM_Core_Error::debug_log_message("Participantletter: Could not send email to participant_id: {$objectRef->id}, contact_id: {$objectRef->contact_id}, template_id: {$template_id}; Email.send API error: " . $e->getMessage());
       }
     }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.